### PR TITLE
Add custom C++ exception handling in Cython

### DIFF
--- a/dwave/optimization/include/dwave-optimization/array.hpp
+++ b/dwave/optimization/include/dwave-optimization/array.hpp
@@ -804,6 +804,10 @@ std::ostream& operator<<(std::ostream& os, const Array::View& view);
 bool array_shape_equal(const Array* lhs_ptr, const Array* rhs_ptr);
 bool array_shape_equal(const Array& lhs, const Array& rhs);
 
+// Test whether multiple arrays all have the same shape.
+bool array_shape_equal(const std::span<const Array* const> array_ptrs);
+bool array_shape_equal(const std::vector<const Array*>& array_ptrs);
+
 /// Get the shape induced by broadcasting two arrays together.
 /// See https://numpy.org/doc/stable/user/basics.broadcasting.html.
 /// Raises an exception if the two arrays cannot be broadcast together

--- a/dwave/optimization/include/dwave-optimization/graph.hpp
+++ b/dwave/optimization/include/dwave-optimization/graph.hpp
@@ -73,6 +73,7 @@ class Graph {
  public:
     Graph();
     ~Graph();
+    Graph(Graph&&);
 
     template <class NodeType, class... Args>
     NodeType* emplace_node(Args&&... args);

--- a/dwave/optimization/include/dwave-optimization/nodes.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes.hpp
@@ -18,6 +18,7 @@
 #include "dwave-optimization/nodes/constants.hpp"
 #include "dwave-optimization/nodes/flow.hpp"
 #include "dwave-optimization/nodes/indexing.hpp"
+#include "dwave-optimization/nodes/lambda.hpp"
 #include "dwave-optimization/nodes/manipulation.hpp"
 #include "dwave-optimization/nodes/mathematical.hpp"
 #include "dwave-optimization/nodes/numbers.hpp"

--- a/dwave/optimization/include/dwave-optimization/nodes/constants.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/constants.hpp
@@ -100,6 +100,17 @@ class ConstantNode : public ArrayOutputMixin<ArrayNode> {
     void commit(State&) const noexcept override {}
     void revert(State&) const noexcept override {}
 
+ protected:
+    // Information about the values in the buffer
+    struct BufferStats {
+        BufferStats() = delete;
+        explicit BufferStats(std::span<const double> buffer);
+
+        bool integral;
+        double min;
+        double max;
+    };
+
  private:
     // Allocate the memory to hold shape worth of doubles, but don't populate it
     explicit ConstantNode(std::initializer_list<ssize_t> shape)
@@ -118,16 +129,48 @@ class ConstantNode : public ArrayOutputMixin<ArrayNode> {
     // holds its values on the object itself rather than in a State.
     double* buffer_ptr_;
 
-    // Information about the values in the buffer
-    struct BufferStats {
-        BufferStats() = delete;
-        explicit BufferStats(std::span<const double> buffer);
-
-        bool integral;
-        double min;
-        double max;
-    };
     mutable std::optional<BufferStats> buffer_stats_;
+};
+
+// InputNode acts like a placeholder or store of data very similar to ConstantNode,
+// with the key different being that its contents *may* change in between propagations.
+// However, it is not a decision variable--instead its use cases are acting as an "input"
+// for "models as functions", or for placeholders in large models where (otherwise constant)
+// data changes infrequently (e.g. a scheduling problem with a preference matrix).
+//
+// Initial values can be provided at node construction that will be used on state initialization.
+// Otherwise, the node will be initialized with all zeros.
+// TODO: finalize the constructors
+class InputNode : public ConstantNode {
+ public:
+    // // A single scalar value
+    // explicit InputNode(double value, double min, double max, bool integral = false)
+    //         : ConstantNode(value), min_(min), max_(max), integral_(integral) { };
+    template<typename... Args>
+    explicit InputNode(double min, double max, bool integral, Args&&... args)
+            : ConstantNode(std::forward<Args&&>(args)...), min_(min), max_(max), integral_(integral) { };
+
+    bool integral() const override { return integral_; };
+
+    double max() const override { return max_; };
+    double min() const override { return min_; };
+
+    void initialize_state(State& state) const override;
+
+    // double const* buff() const;
+    double const* buff(const State&) const override;
+
+    std::span<const Update> diff(const State& state) const noexcept override;
+
+    void propagate(State& state) const noexcept override {};
+    void commit(State& state) const noexcept override;
+    void revert(State& state) const noexcept override;
+
+    void assign(State& state, std::vector<double>& new_values) const;
+
+ private:
+    double min_, max_;
+    bool integral_;
 };
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/nodes/constants.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/constants.hpp
@@ -143,12 +143,17 @@ class ConstantNode : public ArrayOutputMixin<ArrayNode> {
 // TODO: finalize the constructors
 class InputNode : public ConstantNode {
  public:
-    // // A single scalar value
-    // explicit InputNode(double value, double min, double max, bool integral = false)
-    //         : ConstantNode(value), min_(min), max_(max), integral_(integral) { };
-    template<typename... Args>
+    template <typename... Args>
     explicit InputNode(double min, double max, bool integral, Args&&... args)
-            : ConstantNode(std::forward<Args&&>(args)...), min_(min), max_(max), integral_(integral) { };
+            : ConstantNode(std::forward<Args&&>(args)...),
+              min_(min),
+              max_(max),
+              integral_(integral){};
+
+    template <typename... Args>
+    explicit InputNode()
+            : InputNode(-std::numeric_limits<double>::infinity(),
+                        std::numeric_limits<double>::infinity(), false, 0.0){};
 
     bool integral() const override { return integral_; };
 
@@ -166,7 +171,8 @@ class InputNode : public ConstantNode {
     void commit(State& state) const noexcept override;
     void revert(State& state) const noexcept override;
 
-    void assign(State& state, std::vector<double>& new_values) const;
+    void assign(State& state, const std::vector<double>& new_values) const;
+    void assign(State& state, std::span<const double> new_values) const;
 
  private:
     double min_, max_;

--- a/dwave/optimization/include/dwave-optimization/nodes/lambda.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/lambda.hpp
@@ -25,7 +25,7 @@ namespace dwave::optimization {
 class NaryReduceNode : public ArrayOutputMixin<ArrayNode> {
  public:
     // Runtime constructor that can be used from Cython/Python
-    NaryReduceNode(Graph&& expression, const std::vector<InputNode*> inputs,
+    NaryReduceNode(Graph&& expression, const std::vector<InputNode*>& inputs,
                    const ArrayNode* output, const std::vector<double>& initial_values,
                    const std::vector<ArrayNode*>& operands);
 

--- a/dwave/optimization/include/dwave-optimization/nodes/lambda.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/lambda.hpp
@@ -22,6 +22,18 @@
 
 namespace dwave::optimization {
 
+class UnsupportedNaryReduceExpressionError : public std::exception {
+ public:
+    UnsupportedNaryReduceExpressionError(const std::string message, const Node* node_ptr = nullptr);
+
+    const char* what() const noexcept override;
+
+    const Node* node_ptr_;
+
+ private:
+    const std::string message_;
+};
+
 class NaryReduceNode : public ArrayOutputMixin<ArrayNode> {
  public:
     // Runtime constructor that can be used from Cython/Python

--- a/dwave/optimization/include/dwave-optimization/nodes/lambda.hpp
+++ b/dwave/optimization/include/dwave-optimization/nodes/lambda.hpp
@@ -1,0 +1,61 @@
+// Copyright 2023 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "dwave-optimization/array.hpp"
+#include "dwave-optimization/graph.hpp"
+#include "dwave-optimization/nodes/constants.hpp"
+
+namespace dwave::optimization {
+
+class NaryReduceNode : public ArrayOutputMixin<ArrayNode> {
+ public:
+    // Runtime constructor that can be used from Cython/Python
+    NaryReduceNode(Graph&& expression, const std::vector<InputNode*> inputs,
+                   const ArrayNode* output, const std::vector<double>& initial_values,
+                   const std::vector<ArrayNode*>& operands);
+
+    // Array overloads
+    double const* buff(const State& state) const override;
+    std::span<const Update> diff(const State& state) const override;
+    ssize_t size(const State& state) const override;
+    std::span<const ssize_t> shape(const State& state) const override;
+    ssize_t size_diff(const State& state) const override;
+    SizeInfo sizeinfo() const override;
+
+    // Information about the values are all inherited from the array
+    bool integral() const override;
+    double min() const override;
+    double max() const override;
+
+    // Node overloads
+    void commit(State& state) const override;
+    void initialize_state(State& state) const override;
+    void propagate(State& state) const override;
+    void revert(State& state) const override;
+
+ private:
+    double evaluate_expression(State& register_) const;
+
+    const Graph expression_;
+    const std::vector<InputNode*> inputs_;
+    const ArrayNode* output_;
+    const std::vector<ArrayNode*> operands_;
+    const std::vector<double> initial_values_;
+};
+
+}  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/python_exception_handling.hpp
+++ b/dwave/optimization/include/dwave-optimization/python_exception_handling.hpp
@@ -1,0 +1,81 @@
+// Copyright 2023 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#pragma once
+
+#include <Python.h>
+
+#include "dwave-optimization/nodes/lambda.hpp"
+
+namespace dwave::optimization::exception_handling {
+
+// Design inspired by the helpful example found here:
+// https://gist.github.com/vyasr/4eddbff25bb197e056eab3ac1dda6f40
+
+PyObject* UnsupportedNaryReduceExpressionPyExc;
+
+void create_custom_exceptions() {
+    UnsupportedNaryReduceExpressionPyExc = PyErr_NewException("dwave.optimization.libcpp.python_exception_handling.UnsupportedNaryReduceExpressionPyExc", NULL, NULL);
+}
+
+void custom_exception_handler() {
+    // Taken from Cython source code 
+    // https://github.com/cython/cython/blob/1c9dd6ab8b0613832c3033f678b354f23e3ce4c0/Cython/Utility/CppSupport.cpp#L10C1-L42C4
+    //
+    // Catch a handful of different errors here and turn them into the
+    // equivalent Python errors.
+    try {
+        if (PyErr_Occurred())
+            ; // let the latest Python exn pass through and ignore the current one
+        else
+            throw;
+    } catch (const std::bad_alloc& exn) {
+        PyErr_SetString(PyExc_MemoryError, exn.what());
+    } catch (const std::bad_cast& exn) {
+        PyErr_SetString(PyExc_TypeError, exn.what());
+    } catch (const std::bad_typeid& exn) {
+        PyErr_SetString(PyExc_TypeError, exn.what());
+    } catch (const std::domain_error& exn) {
+        PyErr_SetString(PyExc_ValueError, exn.what());
+    } catch (const std::invalid_argument& exn) {
+        PyErr_SetString(PyExc_ValueError, exn.what());
+    } catch (const std::ios_base::failure& exn) {
+        // Unfortunately, in standard C++ we have no way of distinguishing EOF
+        // from other errors here; be careful with the exception mask
+        PyErr_SetString(PyExc_IOError, exn.what());
+    } catch (const std::out_of_range& exn) {
+        // Change out_of_range to IndexError
+        PyErr_SetString(PyExc_IndexError, exn.what());
+    } catch (const std::overflow_error& exn) {
+        PyErr_SetString(PyExc_OverflowError, exn.what());
+    } catch (const std::range_error& exn) {
+        PyErr_SetString(PyExc_ArithmeticError, exn.what());
+    } catch (const std::underflow_error& exn) {
+        PyErr_SetString(PyExc_ArithmeticError, exn.what());
+    }
+
+    // Now catch any custom exceptions
+    catch (const dwave::optimization::UnsupportedNaryReduceExpressionError& exn) {
+        PyErr_SetString(UnsupportedNaryReduceExpressionPyExc, exn.what());
+    }
+
+    // Finally catch general exceptions
+    catch (const std::exception& exn) {
+        PyErr_SetString(PyExc_RuntimeError, exn.what());
+    } catch (...) {
+        PyErr_SetString(PyExc_RuntimeError, "Unknown exception");
+    }
+}
+
+}  // namespace dwave::optimization::exception_handling

--- a/dwave/optimization/include/dwave-optimization/utils.hpp
+++ b/dwave/optimization/include/dwave-optimization/utils.hpp
@@ -16,6 +16,7 @@
 
 #include <iostream>
 #include <numeric>
+#include <variant>
 #include <vector>
 
 namespace dwave::optimization {
@@ -165,5 +166,24 @@ void deduplicate_diff(std::vector<Update>& diff);
 
 // Return whether the given double encodes an integer.
 bool is_integer(const double& value);
+
+// Forward declaration
+class ArrayNode;
+
+template <class T, class... Ts, class node_type>
+bool is_variant(const node_type* node_ptr) {
+    // If the pointer can be dynamically cast to this type, return true
+    if (dynamic_cast<const T*>(node_ptr)) {
+        return true;
+    }
+
+    // If there are still types left to check then "recurse"
+    if constexpr (sizeof...(Ts) > 0) {
+        return is_variant<Ts...>(node_ptr);
+    }
+
+    // If none match, then just return the Node*;
+    return false;
+}
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/include/dwave-optimization/utils.hpp
+++ b/dwave/optimization/include/dwave-optimization/utils.hpp
@@ -182,7 +182,7 @@ bool is_variant(const node_type* node_ptr) {
         return is_variant<Ts...>(node_ptr);
     }
 
-    // If none match, then just return the Node*;
+    // If none match, then this Node didn't belong to the list of types
     return false;
 }
 

--- a/dwave/optimization/libcpp/graph.pxd
+++ b/dwave/optimization/libcpp/graph.pxd
@@ -20,11 +20,12 @@ from libcpp.memory cimport shared_ptr, unique_ptr
 from libcpp.vector cimport vector
 
 from dwave.optimization.libcpp.array cimport Array, span
+from dwave.optimization.libcpp.python_exception_handling cimport custom_exception_handler
 from dwave.optimization.libcpp.state cimport State
 
 cdef extern from "dwave-optimization/graph.hpp" namespace "dwave::optimization" nogil:
     cdef cppclass Graph:
-        T* emplace_node[T](...) except+
+        T* emplace_node[T](...) except+ custom_exception_handler
         void initialize_state(State&) except+
         span[const unique_ptr[Node]] nodes() const
         span[ArrayNode*] constraints() const

--- a/dwave/optimization/libcpp/nodes.pxd
+++ b/dwave/optimization/libcpp/nodes.pxd
@@ -56,6 +56,9 @@ cdef extern from "dwave-optimization/nodes/constants.hpp" namespace "dwave::opti
     cdef cppclass ConstantNode(ArrayNode):
         const double* buff() const
 
+    cdef cppclass InputNode(ArrayNode):
+        const double* buff() const
+
 
 cdef extern from "dwave-optimization/nodes/flow.hpp" namespace "dwave::optimization" nogil:
     cdef cppclass WhereNode(ArrayNode):
@@ -74,6 +77,11 @@ cdef extern from "dwave-optimization/nodes/indexing.hpp" namespace "dwave::optim
         vector[slice_or_int] infer_indices() except +
 
     cdef cppclass PermutationNode(ArrayNode):
+        pass
+
+
+cdef extern from "dwave-optimization/nodes/lambda.hpp" namespace "dwave::optimization" nogil:
+    cdef cppclass NaryReduceNode(ArrayNode):
         pass
 
 

--- a/dwave/optimization/libcpp/python_exception_handling.pxd
+++ b/dwave/optimization/libcpp/python_exception_handling.pxd
@@ -1,0 +1,25 @@
+# distutils: language = c++
+# distutils: include_dirs = dwave/optimization/include/
+
+# Copyright 2024 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+cdef extern from "Python.h" nogil:
+    ctypedef struct PyObject
+
+
+cdef extern from "dwave-optimization/python_exception_handling.hpp" namespace "dwave::optimization::exception_handling":
+    cdef PyObject* UnsupportedNaryReduceExpressionPyExc
+    cdef void create_custom_exceptions()
+    cdef void custom_exception_handler()

--- a/dwave/optimization/model.pyx
+++ b/dwave/optimization/model.pyx
@@ -383,6 +383,11 @@ cdef class Model:
 
         return model
 
+    def input(self, lower_bound: float, upper_bound: float, bool integral):
+        """TODO"""
+        from dwave.optimization.symbols import Input
+        return Input(self, lower_bound, upper_bound, integral, [0])
+
     def integer(self, shape=None, lower_bound=None, upper_bound=None):
         r"""Create an integer symbol as a decision variable.
 

--- a/dwave/optimization/src/array.cpp
+++ b/dwave/optimization/src/array.cpp
@@ -14,6 +14,8 @@
 
 #include "dwave-optimization/array.hpp"
 
+#include <ranges>
+
 namespace dwave::optimization {
 
 SizeInfo::SizeInfo(const Array* array_ptr, std::optional<ssize_t> min, std::optional<ssize_t> max)
@@ -194,6 +196,41 @@ bool array_shape_equal(const Array* lhs_ptr, const Array* rhs_ptr) {
 }
 bool array_shape_equal(const Array& lhs, const Array& rhs) {
     return array_shape_equal(&lhs, &rhs);
+}
+
+bool array_shape_equal(const std::span<const Array* const> array_ptrs) {
+    if (array_ptrs.size() == 0) {
+        return false;
+    }
+
+    const Array* first_ptr = array_ptrs[0];
+    auto first_size = first_ptr->sizeinfo();
+    while (first_size.array_ptr != nullptr && first_size.array_ptr != first_ptr) {
+        first_ptr = first_size.array_ptr;
+        first_size = first_size.substitute();
+    }
+
+    for (const Array* array_ptr : array_ptrs | std::views::take(1)) {
+        auto this_size = array_ptr->sizeinfo();
+
+        if (first_size == this_size) continue;
+        if (this_size.array_ptr == nullptr) return false;
+
+        while (this_size.array_ptr != nullptr && this_size.array_ptr != array_ptr) {
+            array_ptr = this_size.array_ptr;
+            this_size = this_size.substitute();
+            if (first_size == this_size) break;
+        }
+
+        // Have to check again as it's possible that `this_size.array_ptr` is nullptr
+        if (first_size != this_size) return false;
+    }
+
+    return true;
+}
+
+bool array_shape_equal(const std::vector<const Array*>& array_ptrs) {
+    return array_shape_equal(std::span<const Array* const>{array_ptrs});
 }
 
 // We follow NumPy's broadcasting rules

--- a/dwave/optimization/src/graph.cpp
+++ b/dwave/optimization/src/graph.cpp
@@ -28,6 +28,7 @@ namespace dwave::optimization {
 
 Graph::Graph() = default;
 Graph::~Graph() = default;
+Graph::Graph(Graph&&) = default;
 
 void Graph::topological_sort() {
     if (topologically_sorted_) return;

--- a/dwave/optimization/src/nodes/constants.cpp
+++ b/dwave/optimization/src/nodes/constants.cpp
@@ -18,6 +18,7 @@
 #include <ranges>
 
 #include "dwave-optimization/utils.hpp"
+#include "_state.hpp"
 
 namespace dwave::optimization {
 
@@ -108,6 +109,52 @@ double ConstantNode::min() const {
 
     // Return the cached value
     return buffer_stats_->min;
+}
+
+void InputNode::initialize_state(State& state) const {
+    int index = this->topological_index();
+    assert(index >= 0 && "must be topologically sorted");
+    assert(static_cast<int>(state.size()) > index && "unexpected state length");
+    assert(state[index] == nullptr && "already initialized state");
+
+    std::vector<double> values;
+    values.assign(this->data().begin(), this->data().end());
+    state[index] = std::make_unique<ArrayNodeStateData>(std::move(values));
+}
+
+double const* InputNode::buff(const State& state) const {
+    return data_ptr<ArrayNodeStateData>(state)->buff();
+}
+
+std::span<const Update> InputNode::diff(const State& state) const noexcept {
+    return data_ptr<ArrayNodeStateData>(state)->diff();
+}
+
+void InputNode::commit(State& state) const noexcept {
+    data_ptr<ArrayNodeStateData>(state)->commit();
+}
+
+void InputNode::revert(State& state) const noexcept {
+    data_ptr<ArrayNodeStateData>(state)->revert();
+}
+
+void InputNode::assign(State& state, std::vector<double>& new_values) const {
+    if (static_cast<ssize_t>(new_values.size()) != this->size()) {
+        throw std::invalid_argument("size of new values must match");
+    }
+
+    BufferStats stats(new_values);
+    if (stats.min < min()) {
+        throw std::invalid_argument("new data contains a value smaller than the min");
+    }
+    if (stats.max > max()) {
+        throw std::invalid_argument("new data contains a value smaller than the min");
+    }
+    if (integral() && !stats.integral) {
+        throw std::invalid_argument("new data contains a non-integral value");
+    }
+
+    data_ptr<ArrayNodeStateData>(state)->assign(new_values);
 }
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/src/nodes/constants.cpp
+++ b/dwave/optimization/src/nodes/constants.cpp
@@ -138,7 +138,7 @@ void InputNode::revert(State& state) const noexcept {
     data_ptr<ArrayNodeStateData>(state)->revert();
 }
 
-void InputNode::assign(State& state, std::vector<double>& new_values) const {
+void InputNode::assign(State& state, std::span<const double> new_values) const {
     if (static_cast<ssize_t>(new_values.size()) != this->size()) {
         throw std::invalid_argument("size of new values must match");
     }
@@ -155,6 +155,10 @@ void InputNode::assign(State& state, std::vector<double>& new_values) const {
     }
 
     data_ptr<ArrayNodeStateData>(state)->assign(new_values);
+}
+
+void InputNode::assign(State& state, const std::vector<double>& new_values) const {
+    this->assign(state, std::span(new_values));
 }
 
 }  // namespace dwave::optimization

--- a/dwave/optimization/src/nodes/lambda.cpp
+++ b/dwave/optimization/src/nodes/lambda.cpp
@@ -23,6 +23,24 @@
 
 namespace dwave::optimization {
 
+// Return a simple JSON encoded string that looks like
+// {"message": ..., "node_ptr": ...}
+// (node_ptr will be ommitted if it's nullptr)
+std::string craft_error_message(const std::string& message, const Node* node_ptr) noexcept {
+    std::string message_ = R"({"message": ")" + message + "\"";
+    if (node_ptr != nullptr) {
+        message_ += R"(, "node_ptr": )" + std::to_string((uintptr_t)(void*)node_ptr);
+    }
+    message_ += "}";
+    return message_;
+}
+
+UnsupportedNaryReduceExpressionError::UnsupportedNaryReduceExpressionError(
+        const std::string message, const Node* node_ptr)
+        : node_ptr_(node_ptr), message_(craft_error_message(message, node_ptr)) {}
+
+const char* UnsupportedNaryReduceExpressionError::what() const noexcept { return message_.c_str(); }
+
 class NaryReduceNodeData : public ArrayNodeStateData {
  public:
     explicit NaryReduceNodeData(std::vector<double>&& values,
@@ -45,30 +63,26 @@ Graph validate_expression(Graph&& expression, const std::vector<InputNode*> inpu
 
     if (expression.num_decisions()) {
         // At least one decision, so the first node must be a decision
-        throw std::invalid_argument(
-                R"({"message": "Expression should not have any decision variables", "node_ptr": )" +
-                std::to_string((uintptr_t)(void*)expression.nodes()[0].get()) + "}");
+        throw UnsupportedNaryReduceExpressionError(
+                "Expression should not have any decision variables", expression.nodes()[0].get());
     }
 
     for (const auto& node_ptr : expression.nodes()) {
         const ArrayNode* array_node = dynamic_cast<const ArrayNode*>(node_ptr.get());
         if (!array_node) {
-            throw std::invalid_argument(
-                    R"({"message": "Expression should contain only array nodes", "node_ptr": )" +
-                    std::to_string((uintptr_t)(void*)node_ptr.get()) + "}");
+            throw UnsupportedNaryReduceExpressionError("Expression should contain only array nodes",
+                                                       node_ptr.get());
         }
 
         if (!is_variant<ConstantNode, MaximumNode, NegativeNode, AddNode, SubtractNode,
                         MultiplyNode>(array_node)) {
-            throw std::invalid_argument(
-                    R"({"message": "Expression contains unsupported node", "node_ptr": )" +
-                    std::to_string((uintptr_t)(void*)node_ptr.get()) + "}");
+            throw UnsupportedNaryReduceExpressionError("Expression contains unsupported node",
+                                                       node_ptr.get());
         }
 
         if (array_node->ndim() != 0) {
-            throw std::invalid_argument(
-                    R"({"message": "Expression should only contain scalars", "node_ptr": )" +
-                    std::to_string((uintptr_t)(void*)node_ptr.get()) + "}");
+            throw UnsupportedNaryReduceExpressionError("Expression should only contain scalars",
+                                                       node_ptr.get());
         }
     }
 

--- a/dwave/optimization/src/nodes/lambda.cpp
+++ b/dwave/optimization/src/nodes/lambda.cpp
@@ -39,27 +39,41 @@ class NaryReduceNodeData : public ArrayNodeStateData {
 
 Graph validate_expression(Graph&& expression, const std::vector<InputNode*> inputs,
                           const ArrayNode* output) {
+    if (!expression.topologically_sorted()) {
+        throw std::invalid_argument("Expression must be topologically sorted");
+    }
+
     if (expression.num_decisions()) {
-        throw std::invalid_argument("Expression should not have any decision variables");
+        // At least one decision, so the first node must be a decision
+        throw std::invalid_argument(
+                R"({"message": "Expression should not have any decision variables", "node_ptr": )"
+                + std::to_string((uintptr_t)(void *)expression.nodes()[0].get()) + "}"
+        );
     }
 
     for (ssize_t node_idx = 0; node_idx < expression.num_nodes(); node_idx++) {
-        const ArrayNode* array_node =
-                dynamic_cast<const ArrayNode*>(expression.nodes()[node_idx].get());
+        const Node* node_ptr = expression.nodes()[node_idx].get();
+        const ArrayNode* array_node = dynamic_cast<const ArrayNode*>(node_ptr);
         if (!array_node) {
-            throw std::invalid_argument("Expression should contain only array nodes, node=" +
-                                        std::to_string(node_idx));
+            throw std::invalid_argument(
+                    R"({"message": "Expression should contain only array nodes", "node_ptr": )"
+                    + std::to_string((uintptr_t)(void *)node_ptr) + "}"
+            );
         }
 
         if (!is_variant<ConstantNode, MaximumNode, NegativeNode, AddNode, SubtractNode,
                         MultiplyNode>(array_node)) {
-            throw std::invalid_argument("Expression contains unsupported node, node=" +
-                                        std::to_string(node_idx));
+            throw std::invalid_argument(
+                    R"({"message": "Expression contains unsupported node", "node_ptr": )"
+                    + std::to_string((uintptr_t)(void *)node_ptr) + "}"
+            );
         }
 
         if (array_node->ndim() != 0) {
-            throw std::invalid_argument("Expression should only contain scalars, node=" +
-                                        std::to_string(node_idx));
+            throw std::invalid_argument(
+                    R"({"message": "Expression should only contain scalars", "node_ptr": )"
+                    + std::to_string((uintptr_t)(void *)node_ptr) + "}"
+            );
         }
     }
 

--- a/dwave/optimization/src/nodes/lambda.cpp
+++ b/dwave/optimization/src/nodes/lambda.cpp
@@ -46,61 +46,47 @@ Graph validate_expression(Graph&& expression, const std::vector<InputNode*> inpu
     if (expression.num_decisions()) {
         // At least one decision, so the first node must be a decision
         throw std::invalid_argument(
-                R"({"message": "Expression should not have any decision variables", "node_ptr": )"
-                + std::to_string((uintptr_t)(void *)expression.nodes()[0].get()) + "}"
-        );
+                R"({"message": "Expression should not have any decision variables", "node_ptr": )" +
+                std::to_string((uintptr_t)(void*)expression.nodes()[0].get()) + "}");
     }
 
-    for (ssize_t node_idx = 0; node_idx < expression.num_nodes(); node_idx++) {
-        const Node* node_ptr = expression.nodes()[node_idx].get();
-        const ArrayNode* array_node = dynamic_cast<const ArrayNode*>(node_ptr);
+    for (const auto& node_ptr : expression.nodes()) {
+        const ArrayNode* array_node = dynamic_cast<const ArrayNode*>(node_ptr.get());
         if (!array_node) {
             throw std::invalid_argument(
-                    R"({"message": "Expression should contain only array nodes", "node_ptr": )"
-                    + std::to_string((uintptr_t)(void *)node_ptr) + "}"
-            );
+                    R"({"message": "Expression should contain only array nodes", "node_ptr": )" +
+                    std::to_string((uintptr_t)(void*)node_ptr.get()) + "}");
         }
 
         if (!is_variant<ConstantNode, MaximumNode, NegativeNode, AddNode, SubtractNode,
                         MultiplyNode>(array_node)) {
             throw std::invalid_argument(
-                    R"({"message": "Expression contains unsupported node", "node_ptr": )"
-                    + std::to_string((uintptr_t)(void *)node_ptr) + "}"
-            );
+                    R"({"message": "Expression contains unsupported node", "node_ptr": )" +
+                    std::to_string((uintptr_t)(void*)node_ptr.get()) + "}");
         }
 
         if (array_node->ndim() != 0) {
             throw std::invalid_argument(
-                    R"({"message": "Expression should only contain scalars", "node_ptr": )"
-                    + std::to_string((uintptr_t)(void *)node_ptr) + "}"
-            );
+                    R"({"message": "Expression should only contain scalars", "node_ptr": )" +
+                    std::to_string((uintptr_t)(void*)node_ptr.get()) + "}");
         }
     }
 
     return expression;
 }
 
-auto get_operands_shape(const std::vector<ArrayNode*>& operands) {
+auto get_operands_shape(const std::vector<InputNode*>& inputs,
+                        const std::vector<double>& initial_values,
+                        const std::vector<ArrayNode*>& operands) {
     if (operands.size() == 0) {
         throw std::invalid_argument("Must have at least one operand");
     }
-    return operands[0]->shape();
-}
 
-NaryReduceNode::NaryReduceNode(Graph&& expression, const std::vector<InputNode*> inputs,
-                               const ArrayNode* output, const std::vector<double>& initial_values,
-                               const std::vector<ArrayNode*>& operands)
-        : ArrayOutputMixin(get_operands_shape(operands)),
-          expression_(validate_expression(std::move(expression), inputs, output)),
-          inputs_(inputs),
-          output_(output),
-          operands_(operands),
-          initial_values_(initial_values) {
-    if (operands_.size() + 1 != inputs.size()) {
+    if (operands.size() + 1 != inputs.size()) {
         throw std::invalid_argument("Expression must have one more InputNode than operands");
     }
 
-    if (operands_.size() + 1 != initial_values.size()) {
+    if (operands.size() + 1 != initial_values.size()) {
         throw std::invalid_argument("Must have same number of initial values as operands");
     }
 
@@ -113,6 +99,18 @@ NaryReduceNode::NaryReduceNode(Graph&& expression, const std::vector<InputNode*>
         throw std::invalid_argument("All operands must have the same shape");
     }
 
+    return operands[0]->shape();
+}
+
+NaryReduceNode::NaryReduceNode(Graph&& expression, const std::vector<InputNode*>& inputs,
+                               const ArrayNode* output, const std::vector<double>& initial_values,
+                               const std::vector<ArrayNode*>& operands)
+        : ArrayOutputMixin(get_operands_shape(inputs, initial_values, operands)),
+          expression_(validate_expression(std::move(expression), inputs, output)),
+          inputs_(inputs),
+          output_(output),
+          operands_(operands),
+          initial_values_(initial_values) {
     for (const auto& op : operands_) {
         add_predecessor(op);
     }

--- a/dwave/optimization/src/nodes/lambda.cpp
+++ b/dwave/optimization/src/nodes/lambda.cpp
@@ -1,0 +1,220 @@
+// Copyright 2023 D-Wave Systems Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include "dwave-optimization/nodes/lambda.hpp"
+
+#include "_state.hpp"
+#include "dwave-optimization/array.hpp"
+#include "dwave-optimization/nodes/constants.hpp"
+#include "dwave-optimization/nodes/mathematical.hpp"
+#include "dwave-optimization/state.hpp"
+#include "dwave-optimization/utils.hpp"
+
+namespace dwave::optimization {
+
+class NaryReduceNodeData : public ArrayNodeStateData {
+ public:
+    explicit NaryReduceNodeData(std::vector<double>&& values,
+                                std::vector<ArrayIterator>&& iterators, State&& state)
+            : ArrayNodeStateData(std::move(values)),
+              iterators(std::move(iterators)),
+              register_(std::move(state)) {}
+
+    // used to avoid reallocating memory for predecessor iterators every propagation
+    std::vector<ArrayIterator> iterators;
+
+    State register_;
+};
+
+Graph validate_expression(Graph&& expression, const std::vector<InputNode*> inputs,
+                          const ArrayNode* output) {
+    if (expression.num_decisions()) {
+        throw std::invalid_argument("Expression should not have any decision variables");
+    }
+
+    for (ssize_t node_idx = 0; node_idx < expression.num_nodes(); node_idx++) {
+        const ArrayNode* array_node =
+                dynamic_cast<const ArrayNode*>(expression.nodes()[node_idx].get());
+        if (!array_node) {
+            throw std::invalid_argument("Expression should contain only array nodes, node=" +
+                                        std::to_string(node_idx));
+        }
+
+        if (!is_variant<ConstantNode, MaximumNode, NegativeNode, AddNode, SubtractNode,
+                        MultiplyNode>(array_node)) {
+            throw std::invalid_argument("Expression contains unsupported node, node=" +
+                                        std::to_string(node_idx));
+        }
+
+        if (array_node->ndim() != 0) {
+            throw std::invalid_argument("Expression should only contain scalars, node=" +
+                                        std::to_string(node_idx));
+        }
+    }
+
+    return expression;
+}
+
+auto get_operands_shape(const std::vector<ArrayNode*>& operands) {
+    if (operands.size() == 0) {
+        throw std::invalid_argument("Must have at least one operand");
+    }
+    return operands[0]->shape();
+}
+
+NaryReduceNode::NaryReduceNode(Graph&& expression, const std::vector<InputNode*> inputs,
+                               const ArrayNode* output, const std::vector<double>& initial_values,
+                               const std::vector<ArrayNode*>& operands)
+        : ArrayOutputMixin(get_operands_shape(operands)),
+          expression_(validate_expression(std::move(expression), inputs, output)),
+          inputs_(inputs),
+          output_(output),
+          operands_(operands),
+          initial_values_(initial_values) {
+    if (operands_.size() + 1 != inputs.size()) {
+        throw std::invalid_argument("Expression must have one more InputNode than operands");
+    }
+
+    if (operands_.size() + 1 != initial_values.size()) {
+        throw std::invalid_argument("Must have same number of initial values as operands");
+    }
+
+    std::vector<const Array*> array_ops;
+    for (const ArrayNode* op : operands) {
+        array_ops.push_back(op);
+    }
+
+    if (!array_shape_equal(array_ops)) {
+        throw std::invalid_argument("All operands must have the same shape");
+    }
+
+    for (const auto& op : operands_) {
+        add_predecessor(op);
+    }
+}
+
+double const* NaryReduceNode::buff(const State& state) const {
+    return data_ptr<NaryReduceNodeData>(state)->buffer.data();
+};
+
+std::span<const Update> NaryReduceNode::diff(const State& state) const {
+    return data_ptr<NaryReduceNodeData>(state)->diff();
+}
+
+ssize_t NaryReduceNode::size(const State& state) const { return operands_[0]->size(state); }
+
+std::span<const ssize_t> NaryReduceNode::shape(const State& state) const {
+    return operands_[0]->shape(state);
+}
+
+ssize_t NaryReduceNode::size_diff(const State& state) const {
+    return data_ptr<NaryReduceNodeData>(state)->size_diff();
+}
+
+SizeInfo NaryReduceNode::sizeinfo() const { return operands_[0]->sizeinfo(); }
+
+bool NaryReduceNode::integral() const { return false; }
+
+double NaryReduceNode::min() const { return -std::numeric_limits<double>::infinity(); }
+
+double NaryReduceNode::max() const { return std::numeric_limits<double>::infinity(); }
+
+void NaryReduceNode::commit(State& state) const { data_ptr<NaryReduceNodeData>(state)->commit(); }
+
+double NaryReduceNode::evaluate_expression(State& register_) const {
+    // First propagate all the nodes
+    for (const auto& node_ptr : expression_.nodes()) {
+        node_ptr->propagate(register_);
+    }
+    // Then commit to clear the diffs
+    for (const auto& node_ptr : expression_.nodes()) {
+        node_ptr->commit(register_);
+    }
+    return output_->view(register_)[0];
+}
+
+void NaryReduceNode::initialize_state(State& state) const {
+    int node_idx = topological_index();
+    assert(node_idx >= 0 && "must be topologically sorted");
+    assert(state[node_idx] == nullptr && "already initialized state");
+
+    ssize_t start_size = this->size(state);
+    ssize_t num_args = operands_.size();
+    std::vector<double> values;
+    State reg;
+    reg = expression_.initialize_state();
+
+    std::vector<ArrayIterator> iterators;
+    for (const ArrayNode* array_ptr : operands_) {
+        iterators.push_back(array_ptr->begin(state));
+    }
+
+    // Get the initial output of the expression
+    for (ssize_t inp_index = 0; inp_index < num_args + 1; inp_index++) {
+        inputs_[inp_index]->assign(reg, std::span(initial_values_).subspan(inp_index, 1));
+    }
+    double val = evaluate_expression(reg);
+
+    // Compute the expression for each subsequent index
+    for (ssize_t index = 0; index < start_size; ++index) {
+        for (ssize_t arg_index = 0; arg_index < num_args; ++arg_index) {
+            double input_val = *iterators[arg_index];
+            inputs_[arg_index]->assign(reg, std::span<double>(&input_val, 1));
+            iterators[arg_index]++;
+        }
+        // Final input comes from the previous expression
+        inputs_[num_args]->assign(reg, std::span(&val, 1));
+        val = evaluate_expression(reg);
+        values.push_back(val);
+    }
+
+    state[node_idx] = std::make_unique<NaryReduceNodeData>(std::move(values), std::move(iterators),
+                                                           std::move(reg));
+}
+
+void NaryReduceNode::propagate(State& state) const {
+    NaryReduceNodeData* data = data_ptr<NaryReduceNodeData>(state);
+    ssize_t new_size = this->size(state);
+    ssize_t num_args = operands_.size();
+
+    data->iterators.clear();
+    for (const ArrayNode* array_ptr : operands_) {
+        data->iterators.push_back(array_ptr->begin(state));
+    }
+
+    // Set inputs to the initial values
+    for (ssize_t inp_index = 0; inp_index < num_args + 1; inp_index++) {
+        inputs_[inp_index]->assign(data->register_,
+                                   std::span(initial_values_).subspan(inp_index, 1));
+    }
+    double val = evaluate_expression(data->register_);
+
+    for (ssize_t index = 0; index < new_size; ++index) {
+        for (ssize_t arg_index = 0; arg_index < num_args; ++arg_index) {
+            double arg_val = *data->iterators[arg_index];
+            inputs_[arg_index]->assign(data->register_, std::span(&arg_val, 1));
+            data->iterators[arg_index]++;
+        }
+        // Final input comes from the previous expression
+        inputs_[num_args]->assign(data->register_, std::span(&val, 1));
+        val = evaluate_expression(data->register_);
+        data->set(index, val);
+    }
+
+    if (data->diff().size()) Node::propagate(state);
+}
+
+void NaryReduceNode::revert(State& state) const { data_ptr<NaryReduceNodeData>(state)->revert(); }
+
+}  // namespace dwave::optimization

--- a/dwave/optimization/symbols.pyi
+++ b/dwave/optimization/symbols.pyi
@@ -90,6 +90,10 @@ class Equal(ArraySymbol):
     ...
 
 
+class Input(ArraySymbol):
+    ...
+
+
 class IntegerVariable(ArraySymbol):
     def lower_bound(self) -> float: ...
     def set_state(self, index: int, state: numpy.typing.ArrayLike): ...
@@ -145,6 +149,10 @@ class NaryMinimum(ArraySymbol):
 
 
 class NaryMultiply(ArraySymbol):
+    ...
+
+
+class NaryReduce(ArraySymbol):
     ...
 
 

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -97,7 +97,6 @@ from dwave.optimization.model cimport ArraySymbol, Model, Symbol
 
 ctypedef cppArrayNode* cppArrayNodePtr  # Cython gets confused when templating pointers
 ctypedef cppNode* cppNodePtr
-ctypedef void* voidPtr
 
 __all__ = [
     "Absolute",

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -23,13 +23,15 @@ import numbers
 cimport cpython.object
 import cython
 import numpy as np
+from typing import Collection
 
 from cpython.ref cimport PyObject
 from cython.operator cimport dereference as deref, typeid
 from libc.math cimport modf
 from libcpp cimport bool
-from libcpp.cast cimport dynamic_cast
+from libcpp.cast cimport dynamic_cast, reinterpret_cast
 from libcpp.optional cimport nullopt, optional
+from libc.stdint cimport uintptr_t
 from libcpp.typeindex cimport type_index
 from libcpp.unordered_map cimport unordered_map
 from libcpp.utility cimport move
@@ -58,6 +60,7 @@ from dwave.optimization.libcpp.nodes cimport (
     DisjointListNode as cppDisjointListNode,
     DisjointListsNode as cppDisjointListsNode,
     EqualNode as cppEqualNode,
+    InputNode as cppInputNode,
     IntegerNode as cppIntegerNode,
     LessEqualNode as cppLessEqualNode,
     ListNode as cppListNode,
@@ -72,6 +75,7 @@ from dwave.optimization.libcpp.nodes cimport (
     NaryMaximumNode as cppNaryMaximumNode,
     NaryMinimumNode as cppNaryMinimumNode,
     NaryMultiplyNode as cppNaryMultiplyNode,
+    NaryReduceNode as cppNaryReduceNode,
     NegativeNode as cppNegativeNode,
     NotNode as cppNotNode,
     OrNode as cppOrNode,
@@ -92,6 +96,8 @@ from dwave.optimization.libcpp.nodes cimport (
 from dwave.optimization.model cimport ArraySymbol, Model, Symbol
 
 ctypedef cppArrayNode* cppArrayNodePtr  # Cython gets confused when templating pointers
+ctypedef cppNode* cppNodePtr
+ctypedef void* voidPtr
 
 __all__ = [
     "Absolute",
@@ -109,6 +115,7 @@ __all__ = [
     "DisjointLists",
     "DisjointList",
     "Equal",
+    "Input",
     "IntegerVariable",
     "LessEqual",
     "ListVariable",
@@ -123,6 +130,7 @@ __all__ = [
     "NaryMaximum",
     "NaryMinimum",
     "NaryMultiply",
+    "NaryReduce",
     "Negative",
     "Not",
     "Or",
@@ -1522,6 +1530,49 @@ cdef class Equal(ArraySymbol):
 _register(Equal, typeid(cppEqualNode))
 
 
+cdef class Input(ArraySymbol):
+    """TODO"""
+
+    # TODO: implement serialization
+
+    def __init__(self, Model model, array_like, lower_bound: float, upper_bound: float, integral: bool):
+        # In the future we won't need to be contiguous, but we do need to be right now
+        array = np.asarray(array_like, dtype=np.double, order="C")
+
+        # Get the shape and strides
+        cdef vector[Py_ssize_t] shape = array.shape
+        cdef vector[Py_ssize_t] strides = array.strides  # not used because contiguous for now
+
+        # Get a pointer to the first element
+        cdef double[:] flat = array.ravel()
+        cdef double* start = NULL
+        if flat.size:
+            start = &flat[0]
+
+        # Get an observing pointer to the C++ InputNode
+        self.ptr = model._graph.emplace_node[cppInputNode](lower_bound, upper_bound, integral, start, shape)
+
+        self.initialize_arraynode(model, self.ptr)
+
+        # Have the parent model hold a reference to the array, so it's kept alive
+        model._data_sources.append(array)
+
+    @staticmethod
+    def _from_symbol(Symbol symbol):
+        cdef cppInputNode* ptr = dynamic_cast_ptr[cppInputNode](symbol.node_ptr)
+        if not ptr:
+            raise TypeError("given symbol cannot be used to construct a Input")
+
+        cdef Input inp = Input.__new__(Input)
+        inp.ptr = ptr
+        inp.initialize_arraynode(symbol.model, ptr)
+        return inp
+
+    cdef cppInputNode* ptr
+
+_register(Input, typeid(cppInputNode))
+
+
 cdef class IntegerVariable(ArraySymbol):
     """Integer decision-variable symbol.
 
@@ -2214,6 +2265,100 @@ cdef class NaryMultiply(ArraySymbol):
     cdef cppNaryMultiplyNode* ptr
 
 _register(NaryMultiply, typeid(cppNaryMultiplyNode))
+
+
+# TODO: consider different location for this?
+class UnsupportedNaryReduceExpression(Exception):
+    def __init__(self, message: str, symbol: Symbol):
+        super().__init__(message)
+        self.symbol = symbol
+
+
+cdef class NaryReduce(ArraySymbol):
+    """TODO"""
+
+    # TODO: implement serialization
+
+    def __init__(
+        self,
+        input_symbols: Collection[Input],
+        ArraySymbol output_symbol,
+        operands: Collection[ArraySymbol],
+        initial_values: Optional[tuple[float]] = None,
+    ):
+        if len(operands) == 0:
+            raise ValueError("must have at least one operand")
+
+        if len(input_symbols) != len(operands) + 1:
+            raise ValueError("must have exactly one more input than number of operands")
+
+        if initial_values is None:
+            initial_values = (0,) * len(input_symbols)
+
+        if len(initial_values) != len(input_symbols):
+            raise ValueError("must have same number of initial values as inputs")
+
+        cdef Model expression = input_symbols[0].model
+        cdef Model model = operands[0].model
+        cdef cppArrayNode* output = output_symbol.array_ptr
+        cdef vector[double] cppinitial_values
+        cdef vector[cppInputNode*] cppinputs
+        cdef vector[cppArrayNode*] cppoperands
+
+        for val in initial_values:
+            cppinitial_values.push_back(val)
+
+        cdef Input inp
+        for node in input_symbols:
+            if node.model != expression:
+                raise ValueError("all inputs must belong to the expression model")
+            inp = <Input?>node
+            cppinputs.push_back(inp.ptr)
+
+        cdef ArraySymbol array
+        for node in operands:
+            if node.model != model:
+                raise ValueError("all predecessors must be from the same model")
+            array = <ArraySymbol?>node
+            cppoperands.push_back(array.array_ptr)
+
+        with expression.lock():
+            try:
+                self.ptr = model._graph.emplace_node[cppNaryReduceNode](
+                    move(expression._graph), cppinputs, output, cppinitial_values, cppoperands
+                )
+            except ValueError as e:
+                raise self._handle_unsupported_expression_exception(expression, e)
+
+        self.initialize_arraynode(model, self.ptr)
+
+    def _handle_unsupported_expression_exception(self, Model expression, exception: ValueError):
+        try:
+            info = json.loads(str(exception))
+        except json.JSONDecodeError:
+            raise RuntimeError("could not parse exception message from NaryReduceNode")
+
+        cdef uintptr_t node_ptr_val = info["node_ptr"]
+        cdef cppNode* node_ptr = reinterpret_cast[cppNodePtr](<void *>node_ptr_val)
+        cdef Symbol symbol = symbol_from_ptr(expression, node_ptr)
+        e = UnsupportedNaryReduceExpression(info["message"], symbol)
+        return e
+
+    @staticmethod
+    def _from_symbol(Symbol symbol):
+        cdef cppNaryReduceNode* ptr = dynamic_cast_ptr[cppNaryReduceNode](
+            symbol.node_ptr
+        )
+        if not ptr:
+            raise TypeError("given symbol cannot be used to construct an NaryReduce")
+        cdef NaryReduce x = NaryReduce.__new__(NaryReduce)
+        x.ptr = ptr
+        x.initialize_arraynode(symbol.model, ptr)
+        return x
+
+    cdef cppNaryReduceNode* ptr
+
+_register(NaryReduce, typeid(cppNaryReduceNode))
 
 
 cdef class Negative(ArraySymbol):

--- a/dwave/optimization/symbols.pyx
+++ b/dwave/optimization/symbols.pyx
@@ -93,6 +93,7 @@ from dwave.optimization.libcpp.nodes cimport (
     WhereNode as cppWhereNode,
     XorNode as cppXorNode,
     )
+from dwave.optimization.libcpp cimport python_exception_handling
 from dwave.optimization.model cimport ArraySymbol, Model, Symbol
 
 ctypedef cppArrayNode* cppArrayNodePtr  # Cython gets confused when templating pointers
@@ -146,6 +147,9 @@ __all__ = [
     "Where",
     "Xor",
     ]
+
+python_exception_handling.create_custom_exceptions()
+_UnsupportedNaryReduceExpressionError = <object>python_exception_handling.UnsupportedNaryReduceExpressionPyExc
 
 # We would like to be able to do constructions like dynamic_cast[cppConstantNode*](...)
 # but Cython does not allow pointers as template types
@@ -2269,7 +2273,10 @@ _register(NaryMultiply, typeid(cppNaryMultiplyNode))
 # TODO: consider different location for this?
 class UnsupportedNaryReduceExpression(Exception):
     def __init__(self, message: str, symbol: Symbol):
-        super().__init__(message)
+        full_message = f"{message}: contains `{type(symbol).__qualname__}` symbol"
+        if isinstance(symbol, ArraySymbol):
+            full_message += f" with shape {symbol.shape()}"
+        super().__init__(full_message)
         self.symbol = symbol
 
 
@@ -2285,17 +2292,8 @@ cdef class NaryReduce(ArraySymbol):
         operands: Collection[ArraySymbol],
         initial_values: Optional[tuple[float]] = None,
     ):
-        if len(operands) == 0:
-            raise ValueError("must have at least one operand")
-
-        if len(input_symbols) != len(operands) + 1:
-            raise ValueError("must have exactly one more input than number of operands")
-
         if initial_values is None:
             initial_values = (0,) * len(input_symbols)
-
-        if len(initial_values) != len(input_symbols):
-            raise ValueError("must have same number of initial values as inputs")
 
         cdef Model expression = input_symbols[0].model
         cdef Model model = operands[0].model
@@ -2326,12 +2324,12 @@ cdef class NaryReduce(ArraySymbol):
                 self.ptr = model._graph.emplace_node[cppNaryReduceNode](
                     move(expression._graph), cppinputs, output, cppinitial_values, cppoperands
                 )
-            except ValueError as e:
+            except _UnsupportedNaryReduceExpressionError as e:
                 raise self._handle_unsupported_expression_exception(expression, e)
 
         self.initialize_arraynode(model, self.ptr)
 
-    def _handle_unsupported_expression_exception(self, Model expression, exception: ValueError):
+    def _handle_unsupported_expression_exception(self, Model expression, exception):
         try:
             info = json.loads(str(exception))
         except json.JSONDecodeError:

--- a/meson.build
+++ b/meson.build
@@ -29,6 +29,7 @@ dwave_optimization_src = [
     'dwave/optimization/src/nodes/constants.cpp',
     'dwave/optimization/src/nodes/flow.cpp',
     'dwave/optimization/src/nodes/indexing.cpp',
+    'dwave/optimization/src/nodes/lambda.cpp',
     'dwave/optimization/src/nodes/manipulation.cpp',
     'dwave/optimization/src/nodes/mathematical.cpp',
     'dwave/optimization/src/nodes/numbers.cpp',

--- a/tests/cpp/meson.build
+++ b/tests/cpp/meson.build
@@ -16,6 +16,7 @@ tests_all = executable(
         'nodes/test_collections.cpp',
         'nodes/test_constants.cpp',
         'nodes/test_flow.cpp',
+        'nodes/test_lambda.cpp',
         'nodes/test_manipulation.cpp',
         'nodes/test_numbers.cpp',
         'nodes/test_quadratic_model.cpp',

--- a/tests/cpp/nodes/test_constants.cpp
+++ b/tests/cpp/nodes/test_constants.cpp
@@ -15,6 +15,7 @@
 #include "catch2/catch_test_macros.hpp"
 #include "dwave-optimization/graph.hpp"
 #include "dwave-optimization/nodes/constants.hpp"
+#include "dwave-optimization/nodes/testing.hpp"
 
 namespace dwave::optimization {
 
@@ -125,6 +126,77 @@ TEST_CASE("ConstantNode") {
 
             THEN("The ConstantNode is mutated accordingly") {
                 CHECK(std::ranges::equal(ptr->data(), std::vector{30, 10, -105, 20}));
+            }
+        }
+    }
+}
+
+TEST_CASE("InputNode") {
+    auto graph = Graph();
+
+    GIVEN("An input node starting with state copied from a vector") {
+        std::vector<double> values = {30, 10, 40, 20};
+        auto ptr = graph.emplace_node<InputNode>(10, 50, true, values);
+        auto val = graph.emplace_node<ArrayValidationNode>(ptr);
+
+        THEN("It copies the values into a 1d array") {
+            CHECK(ptr->ndim() == 1);
+            CHECK(ptr->size() == 4);
+            CHECK(std::ranges::equal(ptr->data(), values));
+            CHECK(std::ranges::equal(ptr->shape(), std::vector{4}));
+            CHECK(std::ranges::equal(ptr->strides(), std::vector{sizeof(double)}));
+        }
+
+        THEN("min/max/integral are set from arguments") {
+            CHECK(ptr->min() == 10);
+            CHECK(ptr->max() == 50);
+            CHECK(ptr->integral());
+        }
+
+        AND_GIVEN("An initialized state") {
+            auto state = graph.initialize_state();
+
+            THEN("The state defaults to the values from the vector") {
+                CHECK(std::ranges::equal(ptr->view(state), values));
+            }
+
+            AND_WHEN("We assign new values and propagate") {
+                std::vector<double> new_values = {20, 10, 49, 50};
+                ptr->assign(state, new_values);
+
+                ptr->propagate(state);
+                val->propagate(state);
+
+                THEN("The InputNode has the new values") {
+                    CHECK(std::ranges::equal(ptr->view(state), new_values));
+                }
+
+                THEN("We can commit") {
+                    ptr->commit(state);
+                    val->commit(state);
+                }
+
+                THEN("We can revert") {
+                    ptr->revert(state);
+                    val->revert(state);
+                }
+            }
+
+            AND_WHEN("We assign invalid values we get an exception") {
+                std::vector<double> new_values = {20, 10, 49, 51};
+                CHECK_THROWS(ptr->assign(state, new_values));
+
+                new_values = {9, 9, 9, 9};
+                CHECK_THROWS(ptr->assign(state, new_values));
+
+                new_values = {9.99, 50.01, 25, 25};
+                CHECK_THROWS(ptr->assign(state, new_values));
+
+                new_values = {20, 20, 20};
+                CHECK_THROWS(ptr->assign(state, new_values));
+
+                new_values = {20, 20, 20, 20, 20};
+                CHECK_THROWS(ptr->assign(state, new_values));
             }
         }
     }

--- a/tests/cpp/nodes/test_lambda.cpp
+++ b/tests/cpp/nodes/test_lambda.cpp
@@ -1,0 +1,213 @@
+// Copyright 2024 D-Wave Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+#include <catch2/catch_test_macros.hpp>
+#include <dwave-optimization/graph.hpp>
+#include <dwave-optimization/nodes/collections.hpp>
+#include <dwave-optimization/nodes/flow.hpp>
+#include <dwave-optimization/nodes/lambda.hpp>
+#include <dwave-optimization/nodes/mathematical.hpp>
+#include <dwave-optimization/nodes/numbers.hpp>
+#include <dwave-optimization/nodes/testing.hpp>
+
+namespace dwave::optimization {
+
+TEST_CASE("NaryReduceNode") {
+    auto graph = Graph();
+
+    GIVEN("A vector<Node*> of constants and an expression") {
+        std::vector<double> i = {0, 1, 2, 2};
+        std::vector<double> j = {1, 2, 4, 3};
+
+        auto args = std::vector<ArrayNode*>{graph.emplace_node<ConstantNode>(i),
+                                            graph.emplace_node<ConstantNode>(j)};
+
+        // x0 * x1 + x2
+        auto expression = Graph();
+        std::vector<InputNode*> inputs = {expression.emplace_node<InputNode>(),
+                                          expression.emplace_node<InputNode>(),
+                                          expression.emplace_node<InputNode>()};
+        auto output_ptr = expression.emplace_node<AddNode>(
+                expression.emplace_node<MultiplyNode>(inputs[0], inputs[1]), inputs[2]);
+        expression.topological_sort();
+
+        THEN("We can create an accumulate node") {
+            std::vector<double> initial_values({1, 2, 3});
+            auto reduce_ptr = graph.emplace_node<NaryReduceNode>(std::move(expression), inputs,
+                                                                 output_ptr, initial_values, args);
+
+            AND_WHEN("We initialize a state") {
+                auto state = graph.initialize_state();
+
+                THEN("The state is correct") {
+                    CHECK(std::ranges::equal(reduce_ptr->view(state), std::vector{5, 7, 15, 21}));
+                }
+            }
+        }
+    }
+
+    GIVEN("Two integer nodes and a more complicated expression") {
+        auto i_ptr = graph.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{5}, -10, 10);
+        auto j_ptr = graph.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{5}, -10, 10);
+
+        // (x0 + 1) * x1 - x2 + 5
+        auto expression = Graph();
+        std::vector<InputNode*> inputs = {expression.emplace_node<InputNode>(),
+                                          expression.emplace_node<InputNode>(),
+                                          expression.emplace_node<InputNode>()};
+        auto output_ptr = expression.emplace_node<AddNode>(
+                expression.emplace_node<SubtractNode>(
+                        expression.emplace_node<MultiplyNode>(
+                                expression.emplace_node<AddNode>(
+                                        inputs[0], expression.emplace_node<ConstantNode>(1)),
+                                inputs[1]),
+                        inputs[2]),
+                expression.emplace_node<ConstantNode>(5));
+        expression.topological_sort();
+
+        THEN("We can create a lambda node") {
+            std::vector<ArrayNode*> args({i_ptr, j_ptr});
+
+            std::vector<double> initial_values({1, 2, 3});
+            auto reduce_ptr = graph.emplace_node<NaryReduceNode>(std::move(expression), inputs,
+                                                                 output_ptr, initial_values, args);
+
+            auto validation_ptr = graph.emplace_node<ArrayValidationNode>(reduce_ptr);
+
+            AND_WHEN("We initialize a state") {
+                auto state = graph.initialize_state();
+
+                THEN("The state is correct") {
+                    CHECK(std::ranges::equal(reduce_ptr->view(state),
+                                             std::vector{-1, 6, -1, 6, -1}));
+                }
+
+                AND_WHEN("We mutate the integers and propagate") {
+                    i_ptr->set_value(state, 4, 4);
+                    j_ptr->set_value(state, 4, 5);
+
+                    i_ptr->set_value(state, 0, 3);
+                    j_ptr->set_value(state, 0, -1);
+
+                    j_ptr->set_value(state, 3, 7);
+
+                    i_ptr->propagate(state);  // [3, 0, 0, 0, 4]
+                    j_ptr->propagate(state);  // [-1, 0, 0, 7, 5]
+                    reduce_ptr->propagate(state);
+                    validation_ptr->propagate(state);
+
+                    THEN("The state is correct") {
+                        CHECK(std::ranges::equal(reduce_ptr->view(state),
+                                                 std::vector{-5, 10, -5, 17, 13}));
+                    }
+                }
+            }
+        }
+    }
+
+    GIVEN("Three integer nodes and an expression") {
+        auto i_ptr = graph.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{5}, 0, 100);
+        auto j_ptr = graph.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{5}, 0, 100);
+
+        // max(x0 + x2, x1)
+        auto expression = Graph();
+        std::vector<InputNode*> inputs = {expression.emplace_node<InputNode>(),
+                                          expression.emplace_node<InputNode>(),
+                                          expression.emplace_node<InputNode>()};
+        auto output_ptr = expression.emplace_node<MaximumNode>(
+                expression.emplace_node<AddNode>(inputs[0], inputs[2]), inputs[1]);
+        expression.topological_sort();
+
+        THEN("We can create a lambda node with basic functions and logic control") {
+            std::vector<ArrayNode*> args({i_ptr, j_ptr});
+
+            std::vector<double> initial_values({0, 0, 0});
+            auto reduce_ptr = graph.emplace_node<NaryReduceNode>(std::move(expression), inputs,
+                                                                 output_ptr, initial_values, args);
+
+            auto validation_ptr = graph.emplace_node<ArrayValidationNode>(reduce_ptr);
+
+            AND_WHEN("We initialize a state") {
+                auto state = graph.empty_state();
+                i_ptr->initialize_state(state, {0, 1, 2, 3, 4});
+                j_ptr->initialize_state(state, {10, 10, 20, 30, 32});
+
+                graph.initialize_state(state);
+
+                THEN("The state is correct") {
+                    CHECK(std::ranges::equal(reduce_ptr->view(state),
+                                             std::vector{10, 11, 20, 30, 34}));
+                }
+
+                AND_WHEN("We mutate the integers and propagate") {
+                    i_ptr->set_value(state, 4, 5);
+
+                    j_ptr->set_value(state, 1, 15);
+                    j_ptr->set_value(state, 2, 15);
+
+                    i_ptr->propagate(state);  // [0, 1, 2, 3, 5]
+                    j_ptr->propagate(state);  // [10, 15, 15, 30, 32]
+                    reduce_ptr->propagate(state);
+                    validation_ptr->propagate(state);
+
+                    THEN("The state is correct") {
+                        CHECK(std::ranges::equal(reduce_ptr->view(state),
+                                                 std::vector{10, 15, 17, 30, 35}));
+                    }
+                }
+            }
+        }
+    }
+
+    GIVEN("A constant node") {
+        std::vector<double> i = {0, 1, 2, 2};
+
+        std::vector<double> initial_values({1});
+        auto args = std::vector<ArrayNode*>{graph.emplace_node<ConstantNode>(i)};
+
+        THEN("We can't create a NaryReduceNode with an expression with decision variables") {
+            auto expression = Graph();
+            std::vector<InputNode*> inputs = {
+                    expression.emplace_node<InputNode>(),
+            };
+            auto output_ptr = expression.emplace_node<AddNode>(
+                    inputs[0], expression.emplace_node<IntegerNode>());
+            expression.topological_sort();
+
+            CHECK_THROWS(graph.emplace_node<NaryReduceNode>(std::move(expression), inputs,
+                                                            output_ptr, initial_values, args));
+        }
+
+        THEN("We can't create a NaryReduceNode with non-scalar nodes") {
+            auto expression = Graph();
+            std::vector<double> inp_state = {0, 1};
+            std::vector<InputNode*> inputs = {
+                    expression.emplace_node<InputNode>(0, 1, false, inp_state),
+            };
+            auto output_ptr = expression.emplace_node<AddNode>(
+                    inputs[0],
+                    expression.emplace_node<IntegerNode>(std::initializer_list<ssize_t>{2}));
+            expression.topological_sort();
+
+            CHECK_THROWS(graph.emplace_node<NaryReduceNode>(std::move(expression), inputs,
+                                                            output_ptr, initial_values, args));
+        }
+
+        // TODO: num initial values
+        // TODO: num args
+        // TODO: unsupported nodes
+    }
+}
+
+}  // namespace dwave::optimization

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -1100,6 +1100,19 @@ class TestDisjointListsVariable(utils.SymbolTests):
             self.assertEqual(s.state_size(), 10 * 8)
 
 
+class TestInput(utils.SymbolTests):
+    def generate_symbols(self):
+        model = Model()
+        inp = model.input(-10, 10, False)
+        model.lock()
+        yield inp
+
+    # TODO: enable once implemented
+    @unittest.skip("not yet implemented")
+    def test_serialization(*args, **kwargs):
+        pass
+
+
 class TestIntegerVariable(utils.SymbolTests):
     def generate_symbols(self):
         model = Model()
@@ -1742,6 +1755,81 @@ class TestNaryMultiply(utils.NaryOpTests):
 
         with self.assertRaises(ValueError):
             x *= b  # after promotion
+
+
+class TestNaryReduce(utils.SymbolTests):
+    def generate_symbols(self):
+        model = Model()
+        c0 = model.constant([0, 0])
+        c1 = model.constant([0, 1])
+
+        exp = Model()
+        inputs = [exp.input(-10, 10, False) for _ in range(3)]
+        sum_ = inputs[0] + inputs[1] + inputs[2]
+
+        acc = dwave.optimization.symbols.NaryReduce(inputs, sum_, (c0, c1))
+
+        model.lock()
+        yield acc
+
+    def test_mismatched_inputs(self):
+        model = Model()
+        c0 = model.constant([0, 0])
+        c1 = model.constant([0, 1])
+
+        exp = Model()
+        inputs = [exp.input(-10, 10, False) for _ in range(3)]
+        sum_ = inputs[0] + inputs[1] + inputs[2]
+
+        with self.assertRaises(ValueError):
+            dwave.optimization.symbols.NaryReduce(inputs, sum_, (c0,))
+
+        with self.assertRaises(ValueError):
+            dwave.optimization.symbols.NaryReduce(inputs[:1], sum_, (c0, c1))
+
+        with self.assertRaises(ValueError):
+            dwave.optimization.symbols.NaryReduce(inputs, sum_, (c0, c1), initial_values=(0,))
+
+    def test_invalid_expressions(self):
+        model = Model()
+        c0 = model.constant([0, 0])
+
+        exp = Model()
+        inputs = [exp.input(-10, 10, False) for _ in range(2)]
+        i = exp.integer()
+        sum_ = inputs[0] + inputs[1]
+
+        try:
+            dwave.optimization.symbols.NaryReduce(inputs, sum_, (c0,))
+            self.assertTrue(False, "should have raise exception")
+        except Exception as e:
+            self.assertIsInstance(e, dwave.optimization.symbols.UnsupportedNaryReduceExpression)
+            self.assertRegex(str(e), "decision")
+            self.assertTrue(i.equals(e.symbol))
+
+        exp = Model()
+        inputs = [exp.input(-10, 10, False) for _ in range(2)]
+        reshape = inputs[0].reshape((1, 1, 1))
+
+        try:
+            dwave.optimization.symbols.NaryReduce(inputs, reshape, (c0,))
+            self.assertTrue(False, "should have raise exception")
+        except Exception as e:
+            self.assertIsInstance(e, dwave.optimization.symbols.UnsupportedNaryReduceExpression)
+            self.assertRegex(str(e), "unsupported node")
+            self.assertTrue(reshape.equals(e.symbol))
+
+        # TODO: craft example with non-scalar... not sure how to do that right now
+
+    # TODO: enable once implemented
+    @unittest.skip("not yet implemented")
+    def test_serialization(*args, **kwargs):
+        pass
+
+    # TODO: enable once implemented
+    @unittest.skip("not yet implemented")
+    def test_state_serialization(*args, **kwargs):
+        pass
 
 
 class TestNegate(utils.UnaryOpTests):


### PR DESCRIPTION
This allows mapping arbitrary C++ exceptions to custom Python exceptions. This is useful for the `NaryReduceNode` constructor where we want to differentiate between normal `std::invalid_argument` exceptions and special ones that have to do with the handling of the expression passed in.